### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/workflows/antigravity-review.yml
+++ b/.github/workflows/antigravity-review.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   review:
     if: vars.ANTIGRAVITY_REVIEW_ENABLED == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-review.yml@ee62a350312f35a8ddd80e316193535f12fb9152
+    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-review.yml@c6cfbd79d66d4632a2bfd89d5da83bb3f9019a95
     with:
       pr_number: ${{ inputs.pr_number }}
       expected_base_sha: ${{ inputs.expected_base_sha }}

--- a/.github/workflows/antigravity-translate.yml
+++ b/.github/workflows/antigravity-translate.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   translate:
     if: vars.TRANSLATIONS_ENABLED == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-translate.yml@ee62a350312f35a8ddd80e316193535f12fb9152
+    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-translate.yml@c6cfbd79d66d4632a2bfd89d5da83bb3f9019a95
     with:
       pr_number: ${{ inputs.pr_number }}
       expected_base_sha: ${{ inputs.expected_base_sha }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -54,7 +54,7 @@ jobs:
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@ee62a350312f35a8ddd80e316193535f12fb9152
+    uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@c6cfbd79d66d4632a2bfd89d5da83bb3f9019a95
     permissions:
       contents: write # the reusable completes the merge
       pull-requests: write # enable auto-merge and update the pull request

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   docs:
-    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@ee62a350312f35a8ddd80e316193535f12fb9152
+    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@c6cfbd79d66d4632a2bfd89d5da83bb3f9019a95
     with:
       content-ref: ${{ github.sha }}
     permissions:

--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -34,4 +34,4 @@ jobs:
     # in a job-level `if:`. An unset variable evaluates false, so this fails safe
     # toward not spending money.
     if: vars.TRANSLATIONS_ENABLED == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/translation-audit.yml@ee62a350312f35a8ddd80e316193535f12fb9152
+    uses: f5-sales-demo/docs-control/.github/workflows/translation-audit.yml@c6cfbd79d66d4632a2bfd89d5da83bb3f9019a95

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Observability
 
 🌐 English |
-[日本語](https://f5-sales-demo.github.io/observability/ja/) |
-[한국어](https://f5-sales-demo.github.io/observability/ko/) |
-[简体中文](https://f5-sales-demo.github.io/observability/zh-cn/) |
-[繁體中文](https://f5-sales-demo.github.io/observability/zh-tw/) |
-[Español](https://f5-sales-demo.github.io/observability/es/) |
-[Português](https://f5-sales-demo.github.io/observability/pt-br/) |
-[Français](https://f5-sales-demo.github.io/observability/fr/) |
-[Deutsch](https://f5-sales-demo.github.io/observability/de/) |
-[Italiano](https://f5-sales-demo.github.io/observability/it/) |
-[العربية](https://f5-sales-demo.github.io/observability/ar/) |
-[हिन्दी](https://f5-sales-demo.github.io/observability/hi/) |
-[ไทย](https://f5-sales-demo.github.io/observability/th/)
+[日本語](https://f5-sales-demo.github.io/was/ja/) |
+[한국어](https://f5-sales-demo.github.io/was/ko/) |
+[简体中文](https://f5-sales-demo.github.io/was/zh-cn/) |
+[繁體中文](https://f5-sales-demo.github.io/was/zh-tw/) |
+[Español](https://f5-sales-demo.github.io/was/es/) |
+[Português](https://f5-sales-demo.github.io/was/pt-br/) |
+[Français](https://f5-sales-demo.github.io/was/fr/) |
+[Deutsch](https://f5-sales-demo.github.io/was/de/) |
+[Italiano](https://f5-sales-demo.github.io/was/it/) |
+[العربية](https://f5-sales-demo.github.io/was/ar/) |
+[हिन्दी](https://f5-sales-demo.github.io/was/hi/) |
+[ไทย](https://f5-sales-demo.github.io/was/th/)
 
 [![GitHub Pages Deploy](https://github.com/f5-sales-demo/observability/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5-sales-demo/observability/actions/workflows/github-pages-deploy.yml)
 [![Repository Settings](https://github.com/f5-sales-demo/observability/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5-sales-demo/observability/actions/workflows/enforce-repo-settings.yml)


### PR DESCRIPTION
Closes #706

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .github/workflows/github-pages-deploy.yml
- .github/workflows/translation-audit.yml
- .github/workflows/antigravity-review.yml
- .github/workflows/antigravity-translate.yml
- .github/workflows/auto-merge.yml
- README.md